### PR TITLE
php and php-fpm now use the same UID and GID as the user of the host filesystem

### DIFF
--- a/etc/docker/php-fpm/Dockerfile
+++ b/etc/docker/php-fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:5.6-fpm
 
 ENV COMPOSER_VERSION 1.0.0-alpha11
 
-RUN apt-get update && apt-get install -y git libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev libicu-dev
+RUN apt-get update && apt-get install -qqy git libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng12-dev libicu-dev
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
 
@@ -14,6 +14,25 @@ RUN echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_connect_back=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_port=9090" >> /usr/local/etc/php/conf.d/xdebug.ini
 
+# grab gosu for easy step-down from root
+# (nicked from https://github.com/docker-library/postgres/blob/master/9.4/Dockerfile)
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
 ADD php.ini /usr/local/etc/php/php.ini
 
+ADD execute.sh /usr/local/bin/execute.sh
+RUN chmod +x /usr/local/bin/execute.sh
+
 WORKDIR /var/www
+
+ENTRYPOINT ["execute.sh"]

--- a/etc/docker/php-fpm/execute.sh
+++ b/etc/docker/php-fpm/execute.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+MYUID=`stat -c "%u" .`
+MYGID=`stat -c "%g" .`
+
+if [ "$MYUID" -gt '0' ]; then
+    usermod -u $MYUID www-data
+    groupmod -g $MYGID www-data
+fi
+
+if [[ "$1" = 'php-fpm' || "$1" = '' ]]; then
+    exec php-fpm
+fi
+
+gosu www-data "$@"


### PR DESCRIPTION
Commands for the php-fpm container are now being piped through a shell script, which  changes the UID and GID for www-data according to the values of the current directory (which is hopefully the directory that is being mapped from the host system into the container).

The script doesn't change any file permissions in order to prevent messing up the host filesystem.
