### PR TITLE
Recompile the container upon container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ RUN set -xe \
     && gulp --env production \
     && bin/console assets:install \
     && mv web/ public/ \
-    && bin/console cache:clear --no-warmup \
     && rm -rf .babelrc \
         bower_components/ \
         bower.json \
@@ -37,7 +36,6 @@ RUN set -xe \
         node_modules/ \
         npm-shrinkwrap.json \
         package.json \
-        var/cache/* \
         var/logs/* \
     && touch var/logs/${SYMFONY_ENV}.log \
     && mkdir -p var/sessions/ var/uploads/ \

--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,29 @@
+#!/usr/bin/env php
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Debug\Debug;
+
+// if you don't want to setup permissions the proper way, just uncomment the following PHP line
+// read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
+//umask(0000);
+
+set_time_limit(0);
+
+/**
+ * @var Composer\Autoload\ClassLoader $loader
+ */
+$loader = require __DIR__.'/../app/autoload.php';
+
+$input = new ArgvInput();
+$env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');
+$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(['--no-debug', '']) && $env !== 'prod';
+
+if ($debug) {
+    Debug::enable();
+}
+
+$kernel = new AppKernel($env, $debug);
+
+$kernel->compile();

--- a/etc/docker/prod/app/entrypoint.sh
+++ b/etc/docker/prod/app/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-bin/console cache:clear
+bin/compile
 chown -R www-data. var/cache/
 cp -r public/* web/
 


### PR DESCRIPTION
Complete cache clear might be heavy upon every container start,
while only compiling the container (to apply custom parameters)
seems to be acceptable.
