### PR TITLE
Add test containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         volumes_from:
             - data
 
-    db:
+    db: &db
         extends:
             file: etc/docker/common/db/docker-compose.yml
             service: db
@@ -40,7 +40,7 @@ services:
         volumes_from:
             - data
 
-    app_debug:
+    app_debug: &app_debug
         <<: *app
         build:
             context: etc/docker/dev/app
@@ -51,6 +51,20 @@ services:
         <<: *web
         links:
             - app_debug:app
+
+    test:
+        <<: *app_debug
+        command: make test
+        environment:
+            SYMFONY_ENV: test
+        links:
+            - db:db_test
+            - blackfire
+
+    db_test:
+        <<: *db
+        volumes:
+            - ./var/docker/test/mysql:/var/lib/mysql
 
     # Set your blackfire IDs and tokens as environment variables
     # in docker-compose.override.yml before building the containers.


### PR DESCRIPTION
This commit adds two more containers to the dev setup:
- test
- db_test

This way tests can be executed in a completely separate environment
from the development containers which makes it more felxible.

It adds one extra step to the setup:

``` bash
$ doco run test make setup
```

Running tests:

``` bash
$ doco run test
```

Downside is that it starts an extra MySQL container.

Also, in many cases MySQL might not even be necessary for running tests
(eg. Liip FunctionalTestBundle is used with SQLite), but that's
probably not the majority and for integration tests MySQL is
necessary anway.
